### PR TITLE
Use stdout instead of stderr

### DIFF
--- a/apyros/metalog.py
+++ b/apyros/metalog.py
@@ -31,7 +31,7 @@ class MetaLog:
             if not os.path.exists("logs"):
                 os.mkdir("logs")
             self.filename = datetime.datetime.now().strftime("logs/meta_%y%m%d_%H%M%S.log")
-            sys.stderr.write( "METALOG: %s\n" % self.filename )
+            sys.stdout.write( "METALOG: %s\n" % self.filename )
             self.f = open( self.filename, "w" )
             self.f.write( str(sys.argv)+"\n" )
             self.f.flush()


### PR DESCRIPTION
When executing a Python script using npm's Python-Shell, the callback was always rejected just because of this , since it was caught as an error.